### PR TITLE
driver overwrite added

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -3,24 +3,20 @@
 -- Build script for "graphics-cfg" files
 
 -- Identify the bundle and module
+
 bundle = ""
 module = "graphics-cfg"
 
 sourcefiles =
-  {
-    "color.cfg","graphics.cfg"
-  }
+   {
+      "color.cfg","graphics.cfg"
+   }
+
 typesetfiles =
-  {
-  }
+   {
+   }
 
-
-installfiles = {"graphics.cfg"}
+installfiles = sourcefiles
 
 -- No automated tests for this bundle
 testfildir = ""
-
-
--- Find and run the build system
-kpse.set_program_name ("kpsewhich")
-dofile (kpse.lookup ("l3build.lua"))

--- a/color.cfg
+++ b/color.cfg
@@ -3,41 +3,39 @@
 \ProvidesFile{color.cfg}%
   [2024/02/28 v1.12 sample color configuration]%
 
-% Using l3 would be nicer here, but this one also works with very old LaTeX
-\def\Gin@DeclareEngineClash#1{%
-  \expandafter\ifnum 
-  \@ifpackageloaded{xcolor}{\@ifpackagelater{xcolor}{2022/06/13}{\z@}{\@ne}}{\@ne}=\z@
-    \@for \@@tmp:=#1 \do {%
-      \edef\@@tmp{%
-        \noexpand\DeclareKeys
-          {
-            \@@tmp .code = {%
-              \noexpand\PackageWarningNoLine{xcolor}{%
-                Explicit driver option \@@tmp\noexpand\space
-                ignored,\noexpand\MessageBreak
-                because detected engine does not support
-                it.\noexpand\MessageBreak
-                We recommend to remove the explicit driver
-                option.\noexpand\MessageBreak
-                Still staying with driver \noexpand\Gin@driver
-              }%
-            },
-            \@@tmp .usage=load
-          }%
-        }%
-      \@@tmp
-    }%
-  \else	
-    \@for \@tempa:=#1 \do {%
-      \expandafter\DeclareOption\expandafter{\@tempa}{%
-	\PackageWarningNoLine{color}{%
-	  Explict driver option \CurrentOption\space ignored,\MessageBreak
-	  because detected engine does not support it.\MessageBreak
-	  We recommend to remove the explicit driver option.\MessageBreak
-	  Still staying with driver \Gin@driver
+\def\Gin@DriverOverwriteMessage#1#2{%
+  \PackageWarningNoLine% Question: Should we use \PackageError here?
+    {#1}{%
+      Explicit driver option #2 ignored,\MessageBreak
+      because detected engine does not support it.\MessageBreak
+      We recomment to remove the explicit driver option.\MessageBreak
+      Still staying with diver \Gin@driver
+    }{}%
+}
+\def\Gin@ForceDriver#1#2{%
+  \def\Gin@driver{#1.def}%
+  \ExecuteOptions{#1}%
+  \ifx\miniltx\undefined
+    \expandafter\ifnum 
+    \@ifpackageloaded{xcolor}{\@ifpackagelater{xcolor}{2022/06/13}{\z@}{\@ne}}{\@ne}=\z@
+      \@for \@@tmp:=#2 \do {%
+	\edef\@@tmp{%
+	  \noexpand\DeclareKeys
+	    {
+	      \@@tmp .code = 
+                \noexpand\Gin@DriverOverwriteMessage{xcolor}{\@@tmp},
+	      \@@tmp .usage=load
+	    }%
+	  }%
+	\@@tmp
+      }%
+    \else
+      \@for \@tempa:=#2 \do {%
+	\expandafter\DeclareOption\expandafter{\@tempa}{%
+	  \Gin@DriverOverwriteMessage{color}{\CurrentOption}%
 	}%
       }%
-    }%
+    \fi
   \fi
 }
 
@@ -75,29 +73,19 @@
 \expandafter\endgroup
 \ifcase\x
   % default case
-  \def\Gin@driver{dvips.def}%
-  \ExecuteOptions{dvips}%
-  \Gin@DeclareEngineClash{pdftex,vtex,xetex,luatex}%
+  \Gin@ForceDriver{dvips}{pdftex,vtex,xetex,luatex}%
 \or
   % pdfTeX is running in pdf mode
-  \def\Gin@driver{pdftex.def}%
-  \ExecuteOptions{pdftex}%
-  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@ForceDriver{pdftex}{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % VTeX is running
-  \def\Gin@driver{vtex.def}%
-  \ExecuteOptions{vtex}%
-  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
+  \Gin@ForceDriver{vtex}{xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
 \or
   % XeTeX is running
-  \def\Gin@driver{xetex.def}%
-  \ExecuteOptions{xetex}%
-  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@ForceDriver{xetex}{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % luatex (> 0.85)
-  \def\Gin@driver{luatex.def}%
-  \ExecuteOptions{luatex}%
-  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@ForceDriver{luatex}{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \else
   \PackageError{color}{Unexpected configuration}{}
 \fi

--- a/color.cfg
+++ b/color.cfg
@@ -14,7 +14,7 @@
               \noexpand\PackageWarningNoLine{xcolor}{%
                 Explicit driver option \@@tmp\noexpand\space
                 ignored,\noexpand\MessageBreak
-                because detexted engine does not support
+                because detected engine does not support
                 it.\noexpand\MessageBreak
                 We recommend to remove the explicit driver
                 option.\noexpand\MessageBreak

--- a/color.cfg
+++ b/color.cfg
@@ -5,7 +5,28 @@
 
 % Using l3 would be nicer here, but this one also works with very old LaTeX
 \def\Gin@DeclareEngineClashs#1{%
-  \@ifpackageloaded{xcolor}{}{%	
+  \@ifpackageloaded{xcolor}{%
+    \@for \@@tmp:=#1 \do {%
+      \edef\@@tmp{%
+        \noexpand\DeclareKeys
+          {
+            \@@tmp .code = {%
+              \noexpand\PackageWarningNoLine{xcolor}{%
+                Explicit driver option \@@tmp\noexpand\space
+                ignored,\noexpand\MessageBreak
+                because detexted engine does not support
+                it.\noexpand\MessageBreak
+                We recommend to remove the explicit driver
+                option.\noexpand\MessageBreak
+                Still staying with driver \noexpand\Gin@driver
+              }%
+            },
+            \@@tmp .usage=load
+          }%
+        }%
+      \@@tmp
+    }%
+  }{%	
     \@for \@tempa:=#1 \do {%
       \DeclareOption{\@tempa}{%
 	\PackageWarningNoLine{color}{%

--- a/color.cfg
+++ b/color.cfg
@@ -18,7 +18,7 @@
   \ifx\miniltx\undefined
     \expandafter\ifnum 
     \@ifpackageloaded{xcolor}{\@ifpackagelater{xcolor}{2022/06/13}{\z@}{\@ne}}{\@ne}=\z@
-      \@for \@@tmp:=#2 \do {%
+      \@for \@@tmp:=#2\do {%
 	\edef\@@tmp{%
 	  \noexpand\DeclareKeys
 	    {
@@ -30,7 +30,7 @@
 	\@@tmp
       }%
     \else
-      \@for \@tempa:=#2 \do {%
+      \@for \@tempa:=#2\do {%
 	\expandafter\DeclareOption\expandafter{\@tempa}{%
 	  \Gin@DriverOverwriteMessage{color}{\CurrentOption}%
 	}%

--- a/color.cfg
+++ b/color.cfg
@@ -1,7 +1,23 @@
 % https://creativecommons.org/publicdomain/zero/1.0/
 
 \ProvidesFile{color.cfg}%
-  [2016/01/02 v1.6 sample color configuration]
+  [2024/02/28 v1.12 sample color configuration]%
+
+% Using l3 would be nicer here, but this one also works with very old LaTeX
+\def\Gin@DeclareEngineClashs#1{%
+  \@ifpackageloaded{xcolor}{}{%	
+    \@for \@tempa:=#1 \do {%
+      \DeclareOption{\@tempa}{%
+	\PackageWarningNoLine{color}{%
+	  Explict driver option \CurrentOption\space ignored,\MessageBreak
+	  because detected engine does not support it.\MessageBreak
+	  We recommend to remove the explicit driver option.\MessageBreak
+	  Still staying with driver \Gin@driver
+	}%
+      }%
+    }%
+  }%
+}
 
 % Select an appropriate default driver
 \begingroup
@@ -39,22 +55,27 @@
   % default case
   \def\Gin@driver{dvips.def}%
   \ExecuteOptions{dvips}%
+  \Gin@DeclareEngineClashs{pdftex,vtex,xetex,luatex}%
 \or
   % pdfTeX is running in pdf mode
   \def\Gin@driver{pdftex.def}%
   \ExecuteOptions{pdftex}%
+  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % VTeX is running
   \def\Gin@driver{vtex.def}%
   \ExecuteOptions{vtex}%
+  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
 \or
   % XeTeX is running
   \def\Gin@driver{xetex.def}%
   \ExecuteOptions{xetex}%
+  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % luatex (> 0.85)
   \def\Gin@driver{luatex.def}%
   \ExecuteOptions{luatex}%
+  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \else
   \PackageError{color}{Unexpected configuration}{}
 \fi

--- a/color.cfg
+++ b/color.cfg
@@ -5,7 +5,8 @@
 
 % Using l3 would be nicer here, but this one also works with very old LaTeX
 \def\Gin@DeclareEngineClashs#1{%
-  \@ifpackageloaded{xcolor}{%
+  \expandafter\ifnum 
+  \@ifpackageloaded{xcolor}{\@ifpackagelater{xcolor}{2022/06/13}{\z@}{\@ne}}{\@ne}=\z@
     \@for \@@tmp:=#1 \do {%
       \edef\@@tmp{%
         \noexpand\DeclareKeys
@@ -26,9 +27,9 @@
         }%
       \@@tmp
     }%
-  }{%	
+  \else	
     \@for \@tempa:=#1 \do {%
-      \DeclareOption{\@tempa}{%
+      \expandafter\DeclareOption\expandafter{\@tempa}{%
 	\PackageWarningNoLine{color}{%
 	  Explict driver option \CurrentOption\space ignored,\MessageBreak
 	  because detected engine does not support it.\MessageBreak
@@ -37,7 +38,7 @@
 	}%
       }%
     }%
-  }%
+  \fi
 }
 
 % Select an appropriate default driver

--- a/color.cfg
+++ b/color.cfg
@@ -4,7 +4,7 @@
   [2024/02/28 v1.12 sample color configuration]%
 
 % Using l3 would be nicer here, but this one also works with very old LaTeX
-\def\Gin@DeclareEngineClashs#1{%
+\def\Gin@DeclareEngineClash#1{%
   \expandafter\ifnum 
   \@ifpackageloaded{xcolor}{\@ifpackagelater{xcolor}{2022/06/13}{\z@}{\@ne}}{\@ne}=\z@
     \@for \@@tmp:=#1 \do {%
@@ -77,27 +77,27 @@
   % default case
   \def\Gin@driver{dvips.def}%
   \ExecuteOptions{dvips}%
-  \Gin@DeclareEngineClashs{pdftex,vtex,xetex,luatex}%
+  \Gin@DeclareEngineClash{pdftex,vtex,xetex,luatex}%
 \or
   % pdfTeX is running in pdf mode
   \def\Gin@driver{pdftex.def}%
   \ExecuteOptions{pdftex}%
-  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % VTeX is running
   \def\Gin@driver{vtex.def}%
   \ExecuteOptions{vtex}%
-  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
+  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
 \or
   % XeTeX is running
   \def\Gin@driver{xetex.def}%
   \ExecuteOptions{xetex}%
-  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % luatex (> 0.85)
   \def\Gin@driver{luatex.def}%
   \ExecuteOptions{luatex}%
-  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \else
   \PackageError{color}{Unexpected configuration}{}
 \fi

--- a/graphics.cfg
+++ b/graphics.cfg
@@ -4,7 +4,7 @@
   [2024/02/28 v1.12 sample graphics configuration]%
 
 % Using l3 would be nicer here, but this one also works with very old LaTeX
-\def\Gin@DeclareEngineClashs#1{%
+\def\Gin@DeclareEngineClash#1{%
   \@for \@tempa:=#1 \do {%
     \DeclareOption{\@tempa}{%
       \PackageWarningNoLine{graphics}{%
@@ -53,27 +53,27 @@
   % default case
   \def\Gin@driver{dvips.def}%
   \ExecuteOptions{dvips}%
-  \Gin@DeclareEngineClashs{pdftex,vtex,xetex,luatex}%
+  \Gin@DeclareEngineClash{pdftex,vtex,xetex,luatex}%
 \or
   % pdfTeX is running in pdf mode
   \def\Gin@driver{pdftex.def}%
   \ExecuteOptions{pdftex}%
-  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % VTeX is running
   \def\Gin@driver{vtex.def}%
   \ExecuteOptions{vtex}%
-  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
+  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
 \or
   % XeTeX is running
   \def\Gin@driver{xetex.def}%
   \ExecuteOptions{xetex}%
-  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % luatex (> 0.85)
   \def\Gin@driver{luatex.def}%
   \ExecuteOptions{luatex}%
-  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \else
   \PackageError{graphics}{Unexpected configuration}{}
 \fi

--- a/graphics.cfg
+++ b/graphics.cfg
@@ -16,7 +16,7 @@
   \def\Gin@driver{#1.def}%
   \ExecuteOptions{#1}%
   \ifx\miniltx\undefined
-      \@for \@tempa:=#2 \do {%
+      \@for \@tempa:=#2\do {%
 	\expandafter\DeclareOption\expandafter{\@tempa}{%
 	  \Gin@DriverOverwriteMessage{graphics}{\CurrentOption}%
 	}%

--- a/graphics.cfg
+++ b/graphics.cfg
@@ -1,7 +1,21 @@
 % https://creativecommons.org/publicdomain/zero/1.0/
 
 \ProvidesFile{graphics.cfg}%
-  [2016/06/04 v1.11 sample graphics configuration]%
+  [2024/02/28 v1.12 sample graphics configuration]%
+
+% Using l3 would be nicer here, but this one also works with very old LaTeX
+\def\Gin@DeclareEngineClashs#1{%
+  \@for \@tempa:=#1 \do {%
+    \DeclareOption{\@tempa}{%
+      \PackageWarningNoLine{graphics}{%
+        Explicte driver option \CurrentOption\space ignored,\MessageBreak
+        because detected engine does not support it.\MessageBreak
+        We recommend to remove the explicite driver option.\MessageBreak
+        Still staying with driver \Gin@driver
+      }%
+    }%
+  }%
+}
 
 % Select an appropriate default driver
 \begingroup
@@ -39,22 +53,27 @@
   % default case
   \def\Gin@driver{dvips.def}%
   \ExecuteOptions{dvips}%
+  \Gin@DeclareEngineClashs{pdftex,vtex,xetex,luatex}%
 \or
   % pdfTeX is running in pdf mode
   \def\Gin@driver{pdftex.def}%
   \ExecuteOptions{pdftex}%
+  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % VTeX is running
   \def\Gin@driver{vtex.def}%
   \ExecuteOptions{vtex}%
+  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
 \or
   % XeTeX is running
   \def\Gin@driver{xetex.def}%
   \ExecuteOptions{xetex}%
+  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % luatex (> 0.85)
   \def\Gin@driver{luatex.def}%
   \ExecuteOptions{luatex}%
+  \Gin@DeclareEngineClashs{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \else
   \PackageError{graphics}{Unexpected configuration}{}
 \fi

--- a/graphics.cfg
+++ b/graphics.cfg
@@ -8,9 +8,9 @@
   \@for \@tempa:=#1 \do {%
     \DeclareOption{\@tempa}{%
       \PackageWarningNoLine{graphics}{%
-        Explicte driver option \CurrentOption\space ignored,\MessageBreak
+        Explict driver option \CurrentOption\space ignored,\MessageBreak
         because detected engine does not support it.\MessageBreak
-        We recommend to remove the explicite driver option.\MessageBreak
+        We recommend to remove the explicit driver option.\MessageBreak
         Still staying with driver \Gin@driver
       }%
     }%

--- a/graphics.cfg
+++ b/graphics.cfg
@@ -3,18 +3,25 @@
 \ProvidesFile{graphics.cfg}%
   [2024/02/28 v1.12 sample graphics configuration]%
 
-% Using l3 would be nicer here, but this one also works with very old LaTeX
-\def\Gin@DeclareEngineClash#1{%
-  \@for \@tempa:=#1 \do {%
-    \DeclareOption{\@tempa}{%
-      \PackageWarningNoLine{graphics}{%
-        Explict driver option \CurrentOption\space ignored,\MessageBreak
-        because detected engine does not support it.\MessageBreak
-        We recommend to remove the explicit driver option.\MessageBreak
-        Still staying with driver \Gin@driver
+\def\Gin@DriverOverwriteMessage#1#2{%
+  \PackageWarningNoLine% Question: Should we use \PackageError here?
+    {#1}{%
+      Explicit driver option #2 ignored,\MessageBreak
+      because detected engine does not support it.\MessageBreak
+      We recomment to remove the explicit driver option.\MessageBreak
+      Still staying with diver \Gin@driver
+    }{}%
+}
+\def\Gin@ForceDriver#1#2{%
+  \def\Gin@driver{#1.def}%
+  \ExecuteOptions{#1}%
+  \ifx\miniltx\undefined
+      \@for \@tempa:=#2 \do {%
+	\expandafter\DeclareOption\expandafter{\@tempa}{%
+	  \Gin@DriverOverwriteMessage{graphics}{\CurrentOption}%
+	}%
       }%
-    }%
-  }%
+  \fi
 }
 
 % Select an appropriate default driver
@@ -51,29 +58,19 @@
 \expandafter\endgroup
 \ifcase\x
   % default case
-  \def\Gin@driver{dvips.def}%
-  \ExecuteOptions{dvips}%
-  \Gin@DeclareEngineClash{pdftex,vtex,xetex,luatex}%
+  \Gin@ForceDriver{dvips}{pdftex,vtex,xetex,luatex}%
 \or
   % pdfTeX is running in pdf mode
-  \def\Gin@driver{pdftex.def}%
-  \ExecuteOptions{pdftex}%
-  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@ForceDriver{pdftex}{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % VTeX is running
-  \def\Gin@driver{vtex.def}%
-  \ExecuteOptions{vtex}%
-  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
+  \Gin@ForceDriver{vtex}{xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi}%
 \or
   % XeTeX is running
-  \def\Gin@driver{xetex.def}%
-  \ExecuteOptions{xetex}%
-  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@ForceDriver{xetex}{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,pdftex,luatex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \or
   % luatex (> 0.85)
-  \def\Gin@driver{luatex.def}%
-  \ExecuteOptions{luatex}%
-  \Gin@DeclareEngineClash{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
+  \Gin@ForceDriver{luatex}{dvips,xdvi,dvipdf,dvipdfm,dvipdftmx,xetex,pdftex,dvisvgm,dvipsone,dviwindo,emtex,dviwin,oztex,textures,pctexwin,pctexhp,pctex32,truetex,tcidvi,vtex}%
 \else
   \PackageError{graphics}{Unexpected configuration}{}
 \fi


### PR DESCRIPTION
I quite often see users loading `graphics` or `graphicx` with totally wrong driver options. The most common case is that (superfluous) option `pdftex` is used and then this is overlooked when switching to XeLaTeX or LuaLaTeX. In both cases, this leads to error messages which the user can usually do little with.

I have therefore created a modification of `graphics.cfg` which basically deactivates the wrong driver options so that only a suitable warning is issued. Instead of a warning, a suitable error message could of course also be output — similar to the `hyperref` package. Which is better is IMHO more a matter of taste.